### PR TITLE
Toggle theme using configuration key map

### DIFF
--- a/example-config/extensible-keys-toggle-theme.hs
+++ b/example-config/extensible-keys-toggle-theme.hs
@@ -13,6 +13,7 @@ import GI.Gdk
 import GI.Vte (Terminal)
 import Termonad
 import Termonad.Config.Colour
+import Termonad.Keys
 import Termonad.Types
 
 main :: IO ()

--- a/example-config/extensible-keys-toggle-theme.hs
+++ b/example-config/extensible-keys-toggle-theme.hs
@@ -21,7 +21,7 @@ main = defaultMain =<< addColourConfig tmc darkTheme
 tmc :: TMConfig
 tmc = defaultTMConfig
   { options = defaultConfigOptions
-  , keys = keys defaultTMConfig <> colourKeys
+  , keys = defaultConfigKeys <> colourKeys
   }
 
 colourKeys :: Map Key (Terminal -> TMState -> TMWindowId -> IO Bool)

--- a/example-config/extensible-keys-toggle-theme.hs
+++ b/example-config/extensible-keys-toggle-theme.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import Termonad
+import Termonad.Config.Colour
+
+main :: IO ()
+main = defaultMain =<< addColourConfig tmc dcc
+
+tmc :: TMConfig
+tmc = defaultTMConfig
+  { options = defaultConfigOptions
+  , keys = keys defaultTMConfig <> colourKeys
+  }
+
+colourKeys :: Map Key (Terminal -> TMState -> TMWindowId -> IO Bool)
+colourKeys = M.fromList
+  [ (KEY_l, setTheme lightTheme)
+  , (KEY_d, setTheme darkTheme)
+  ]
+
+setTheme
+  :: ColourConfig (AlphaColour Double)
+  -> Terminal
+  -> TMState
+  -> TMWindowId
+  -> IO ()
+setTheme theme vteTerm tmState _ = do
+  mVarTheme <- newMVar theme
+  colourHook mVarTheme tmState vteTerm
+
+lightTheme :: ColourConfig (AlphaColour Double)
+lightTheme = defaultColourConfig
+      { foregroundColour = Set $ createColour 0x1d 0x1f 0x21
+      , backgroundColour = Set $ createColour 0xc5 0xc8 0xc6
+      , palette = ExtendedPalette stdCs extCs
+      }
+
+darkTheme :: ColourConfig (AlphaColour Double)
+darkTheme = defaultColourConfig
+      { foregroundColour = Set $ createColour 0xc5 0xc8 0xc6
+      , backgroundColour = Set $ createColour 0x1d 0x1f 0x21
+      , palette = ExtendedPalette stdCs extCs
+      }
+
+stdCs :: List8 (AlphaColour Double)
+stdCs = unsafeMkList8
+      [ createColour 0x28 0x2a 0x2e -- black
+      , createColour 0xa5 0x42 0x42 -- red
+      , createColour 0x8c 0x94 0x40 -- green
+      , createColour 0xde 0x93 0x5f -- orange
+      , createColour 0x5f 0x81 0x9d -- blue
+      , createColour 0x85 0x67 0x8f -- violet
+      , createColour 0x5e 0x8d 0x87 -- indigo
+      , createColour 0x70 0x78 0x80 -- white
+      ]
+extCs :: List8 (AlphaColour Double)
+extCs = unsafeMkList8
+      [ createColour 0x37 0x3b 0x41 -- black
+      , createColour 0xcc 0x66 0x66 -- red
+      , createColour 0xb5 0xbd 0x68 -- green
+      , createColour 0xf0 0xc6 0x74 -- yellow
+      , createColour 0x81 0xa2 0xbe -- blue
+      , createColour 0xb2 0x94 0xbb -- violet
+      , createColour 0x8a 0xbe 0xb7 -- indigo
+      , createColour 0xc5 0xc8 0xc6 -- white
+      ]

--- a/example-config/extensible-keys-toggle-theme.hs
+++ b/example-config/extensible-keys-toggle-theme.hs
@@ -1,12 +1,22 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms   #-}
 
+import Control.Concurrent
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import GI.Gdk
+  ( pattern KEY_d
+  , pattern KEY_l
+  , ModifierType(..)
+  )
+import GI.Vte (Terminal)
 import Termonad
 import Termonad.Config.Colour
+import Termonad.Types
 
 main :: IO ()
-main = defaultMain =<< addColourConfig tmc dcc
+main = defaultMain =<< addColourConfig tmc darkTheme
 
 tmc :: TMConfig
 tmc = defaultTMConfig
@@ -16,8 +26,8 @@ tmc = defaultTMConfig
 
 colourKeys :: Map Key (Terminal -> TMState -> TMWindowId -> IO Bool)
 colourKeys = M.fromList
-  [ (KEY_l, setTheme lightTheme)
-  , (KEY_d, setTheme darkTheme)
+  [ (toKey KEY_l $ S.singleton ModifierTypeMod1Mask, \vteTerm -> stopProp (setTheme lightTheme vteTerm))
+  , (toKey KEY_d $ S.singleton ModifierTypeMod1Mask, \vteTerm -> stopProp (setTheme darkTheme vteTerm))
   ]
 
 setTheme

--- a/src/Termonad/Keys.hs
+++ b/src/Termonad/Keys.hs
@@ -17,7 +17,7 @@ import GI.Gdk
   , getEventKeyString
   , getEventKeyType
   )
-
+import GI.Vte (Terminal)
 import Termonad.Types
   ( Key(..)
   , TMState

--- a/src/Termonad/Keys.hs
+++ b/src/Termonad/Keys.hs
@@ -71,8 +71,8 @@ removeStrangeModifiers Key{keyVal, keyMods} =
   in Key keyVal (Set.difference keyMods reservedModifiers)
 
 
-handleKeyPress :: TMState -> TMWindowId -> EventKey -> IO Bool
-handleKeyPress terState tmWindowId eventKey = do
+handleKeyPress :: Terminal -> TMState -> TMWindowId -> EventKey -> IO Bool
+handleKeyPress vteTerm terState tmWindowId eventKey = do
   -- void $ showKeys eventKey
   keyval <- getEventKeyKeyval eventKey
   modifiers <- getEventKeyState eventKey
@@ -80,5 +80,5 @@ handleKeyPress terState tmWindowId eventKey = do
       newKey = removeStrangeModifiers oldKey
   maybeAction <- Map.lookup newKey . keys . tmStateConfig <$> readMVar terState
   case maybeAction of
-    Just action -> action terState tmWindowId
+    Just action -> action vteTerm terState tmWindowId
     Nothing -> pure False

--- a/src/Termonad/Preferences/File.hs
+++ b/src/Termonad/Preferences/File.hs
@@ -39,7 +39,7 @@ import Termonad.Types
   , TMConfig(TMConfig, hooks, options, keys)
   , defaultConfigHooks
   , defaultConfigOptions
-  , defaultConfigKeyMap
+  , defaultConfigKeys
   )
 
 -- $setup
@@ -77,7 +77,7 @@ tmConfigFromPreferencesFile = do
       Right options -> pure options
   pure TMConfig { options = options
                 , hooks = defaultConfigHooks
-                , keys = defaultConfigKeyMap 
+                , keys = defaultConfigKeys
                 }
 
 -- | Read the 'ConfigOptions' out of a configuration file.

--- a/src/Termonad/Term.hs
+++ b/src/Termonad/Term.hs
@@ -456,7 +456,7 @@ setFocusOn tmStateAppWin vteTerm = do
 
 -- | Create a new 'TMTerm', setting it up and adding it to the GTKNotebook.
 createTerm
-  :: (TMState -> TMWindowId -> EventKey -> IO Bool)
+  :: (Terminal -> TMState -> TMWindowId -> EventKey -> IO Bool)
   -- ^ Funtion for handling key presses on the terminal.
   -> TMState
   -> TMWindowId
@@ -502,8 +502,8 @@ createTerm handleKeyPress mvarTMState tmWinId = do
   void $ onButtonClicked tabCloseButton $ termClose notebookTab mvarTMState tmWinId
   void $ onTerminalWindowTitleChanged vteTerm $ do
     relabelTab (tmNotebook currNote) tabLabel scrolledWin vteTerm
-  void $ onWidgetKeyPressEvent vteTerm $ handleKeyPress mvarTMState tmWinId
-  void $ onWidgetKeyPressEvent scrolledWin $ handleKeyPress mvarTMState tmWinId
+  void $ onWidgetKeyPressEvent vteTerm $ handleKeyPress vteTerm mvarTMState tmWinId
+  void $ onWidgetKeyPressEvent scrolledWin $ handleKeyPress vteTerm mvarTMState tmWinId
   void $ onWidgetButtonPressEvent vteTerm $ handleMousePress appWin vteTerm
   void $ onTerminalChildExited vteTerm $ \_ -> termExit notebookTab mvarTMState tmWinId
 

--- a/src/Termonad/Types.hs
+++ b/src/Termonad/Types.hs
@@ -637,7 +637,7 @@ data Key = Key
 toKey :: Word32 -> Set ModifierType -> Key
 toKey = Key
 
-defaultConfigKeyMap :: Map Key (TMState -> TMWindowId -> IO Bool)
+defaultConfigKeyMap :: Map Key (Terminal -> TMState -> TMWindowId -> IO Bool)
 defaultConfigKeyMap =
   let numKeys :: [Word32]
       numKeys =

--- a/src/Termonad/Types.hs
+++ b/src/Termonad/Types.hs
@@ -612,7 +612,7 @@ defaultConfigOptions =
 data TMConfig = TMConfig
   { options :: !ConfigOptions
   , hooks :: !ConfigHooks
-  , keys :: !(Map Key (TMState -> TMWindowId -> IO Bool))
+  , keys :: !(Map Key (Terminal -> TMState -> TMWindowId -> IO Bool))
   }
 
 instance Show TMConfig where
@@ -652,11 +652,11 @@ defaultConfigKeyMap =
         , KEY_9
         , KEY_0
         ]
-      altNumKeys :: [(Key, TMState -> TMWindowId -> IO Bool)]
+      altNumKeys :: [(Key, Terminal -> TMState -> TMWindowId -> IO Bool)]
       altNumKeys =
         imap
           (\i k ->
-             (toKey k [ModifierTypeMod1Mask], stopProp (altNumSwitchTerm i))
+             (toKey k [ModifierTypeMod1Mask], const $ stopProp (altNumSwitchTerm i))
           )
           numKeys
   in

--- a/src/Termonad/Types.hs
+++ b/src/Termonad/Types.hs
@@ -626,7 +626,7 @@ defaultTMConfig =
   TMConfig
     { options = defaultConfigOptions
     , hooks = defaultConfigHooks
-    , keys = defaultConfigKeyMap
+    , keys = defaultConfigKeys
     }
 
 data Key = Key
@@ -637,8 +637,8 @@ data Key = Key
 toKey :: Word32 -> Set ModifierType -> Key
 toKey = Key
 
-defaultConfigKeyMap :: Map Key (Terminal -> TMState -> TMWindowId -> IO Bool)
-defaultConfigKeyMap =
+defaultConfigKeys :: Map Key (Terminal -> TMState -> TMWindowId -> IO Bool)
+defaultConfigKeys =
   let numKeys :: [Word32]
       numKeys =
         [ KEY_1


### PR DESCRIPTION
Toggle light and dark theme using the extensible key map. See example.

Light theme: <kbd>Alt</kbd> + <kbd>l</kbd>

Dark theme: <kbd>Alt</kbd> + <kbd>d</kbd>